### PR TITLE
Add "massSpec" column to the MsInstrument table to distinguish non-mass spec devices (e.g. HPLC)

### DIFF
--- a/WebRoot/pages/admin/addInstrument.jsp
+++ b/WebRoot/pages/admin/addInstrument.jsp
@@ -61,6 +61,13 @@
                 </td>
             </tr>
             <tr>
+                <td class="left_align"><b>Mass Spectrometer:</b></td>
+                <td class="left_align">
+                    <html:radio name="addInstrumentForm" property="massSpec" value="true">Yes</html:radio>
+                    <html:radio name="addInstrumentForm" property="massSpec" value="false">No</html:radio>
+                </td>
+            </tr>
+            <tr>
                 <td class="left_align"><b>Color:</b></td>
                 <td class="left_align">
                     <input id="colorPicker"/> <span id="chosenColor" style="padding:5px;"></span>

--- a/WebRoot/pages/admin/manageInstruments.jsp
+++ b/WebRoot/pages/admin/manageInstruments.jsp
@@ -38,6 +38,7 @@
                 <th>Name</th>
                 <th>Description</th>
                 <th>Active</th>
+                <th>Mass Spec</th>
                 <th></th>
                 <th></th>
             </tr>
@@ -52,8 +53,12 @@
                     </td>
                     <td class="left_align"><bean:write name="instrument" property="description"/></td>
                     <td class="left_align">
-                        <logic:equal name="instrument" property="active" value="true"><span style="color:green; font-style:bold;">YES</span></logic:equal>
+                        <logic:equal name="instrument" property="active" value="true"><span style="color:green; font-weight:bold;">YES</span></logic:equal>
                         <logic:equal name="instrument" property="active" value="false"><span style="color:red;">NO</span></logic:equal>
+                    </td>
+                    <td class="left_align">
+                        <logic:equal name="instrument" property="massSpec" value="true">YES</logic:equal>
+                        <logic:equal name="instrument" property="massSpec" value="false">NO</logic:equal>
                     </td>
                     <td><font color="green">
                         <html:link action="/editInstrument.do" paramId="instrumentId" paramName="instrument" paramProperty="ID">Edit</html:link>

--- a/WebRoot/pages/internal/project/payment/newPaymentMethod.jsp
+++ b/WebRoot/pages/internal/project/payment/newPaymentMethod.jsp
@@ -48,7 +48,7 @@
 	<tr>
 		<td>Resource Worktag:</td>
 		<td>
-			<html:text  property="resourceWorktag"/> <span style="font-size:10px;">format: RS######. <span style="color:red;">Required for PG, CC and some SAG, GR worktags</span></span>
+			<html:text  property="resourceWorktag"/> <span style="font-size:10px;">format: RS######. <span style="color:red;">Required for CC worktags</span></span>
 		</td>
 	</tr>
 	<tr>

--- a/WebRoot/pages/internal/project/payment/viewPaymentMethod.jsp
+++ b/WebRoot/pages/internal/project/payment/viewPaymentMethod.jsp
@@ -44,11 +44,11 @@ function backToProject(projectId) {
                 </logic:notEmpty>
                 <tr>
                     <td>Total used: </td>
-                    <td>$<bean:write name="paymentMethodUsage" property="totalCost"/></td>
+                    <td>$<bean:write name="paymentMethodUsage" property="totalCostFormatted"/></td>
                 </tr>
                 <tr>
                     <td>Invoiced: </td>
-                    <td>$<bean:write name="paymentMethodUsage" property="invoicedCost"/></td>
+                    <td>$<bean:write name="paymentMethodUsage" property="invoicedCostFormatted"/></td>
                 </tr>
                 <logic:notEmpty name="paymentMethod" property="ponumber">
                     <tr>

--- a/WebRoot/pages/internal/project/viewBilledProject.jsp
+++ b/WebRoot/pages/internal/project/viewBilledProject.jsp
@@ -191,16 +191,16 @@
 							PaymentMethodUsage pmu = new PaymentMethodUsage(((PaymentMethod)paymentMethod).getId());
 						%>
 					<td style="padding:3px">
-						$<%=pmu.getSetupCost()%>
+						<%=pmu.getSetupCostFormatted()%>
 					</td>
 					<td style="padding:3px">
-						$<%=pmu.getInstrumentCost()%>
+						<%=pmu.getInstrumentCostFormatted()%>
 					</td>
                     <td style="padding:3px">
-                        $<%=pmu.getTotalCost()%>
+                        <%=pmu.getTotalCostFormatted()%>
                     </td>
                     <td style="padding:3px">
-                        $<%=pmu.getInvoicedCost()%>
+                        <%=pmu.getInvoicedCostFormatted()%>
                     </td>
 					<td style="padding:3px">
 						<nobr>

--- a/schema/updateScripts/instrument_is_mass_spec.sql
+++ b/schema/updateScripts/instrument_is_mass_spec.sql
@@ -1,0 +1,1 @@
+ALTER TABLE msData.msInstrument ADD COLUMN massSpec boolean default true;

--- a/src/org/uwpr/instrumentlog/MsInstrument.java
+++ b/src/org/uwpr/instrumentlog/MsInstrument.java
@@ -7,18 +7,20 @@ public class MsInstrument {
 	private String description;
 	private boolean active;
 	private String color;
+	private boolean isMassSpec;
 
 	public MsInstrument(){}
 
-	public MsInstrument(int id, String name, String description, boolean active) {
+	public MsInstrument(int id, String name, String description, boolean active, boolean isMassSpec) {
 		this.id = id;
 		this.name = name;
 		this.description = description;
 		this.active = active;
+		this.isMassSpec = isMassSpec;
 	}
 
-	public MsInstrument(int id, String name, String description, boolean active, String color) {
-		this(id, name, description, active);
+	public MsInstrument(int id, String name, String description, boolean active, boolean isMassSpec, String color) {
+		this(id, name, description, active, isMassSpec);
 		this.color = color;
 	}
 
@@ -45,6 +47,11 @@ public class MsInstrument {
 	
 	public boolean isActive() {
 		return active;
+	}
+
+	public boolean isMassSpec()
+	{
+		return isMassSpec;
 	}
 
 	public String getColor()
@@ -74,6 +81,11 @@ public class MsInstrument {
 	public void setActive(boolean active)
 	{
 		this.active = active;
+	}
+
+	public void setMassSpec(boolean massSpec)
+	{
+		this.isMassSpec = massSpec;
 	}
 
 	public void setColor(String color)

--- a/src/org/uwpr/instrumentlog/MsInstrumentUtils.java
+++ b/src/org/uwpr/instrumentlog/MsInstrumentUtils.java
@@ -66,6 +66,18 @@ public class MsInstrumentUtils {
 		}
 		return null;
 	}
+
+	public List<Integer> getAccessoryInstrumentIds()
+	{
+		List<MsInstrument> instruments = MsInstrumentUtils.instance().getMsInstruments(true);
+		List<Integer> accessories = new ArrayList<>();
+		for (MsInstrument instrument : instruments)
+		{
+			if (instrument.isMassSpec()) continue;
+			accessories.add(instrument.getID()); // Add-ons such as HPLC
+		}
+		return accessories;
+	}
 	
 	public List <MsInstrument> getMsInstruments(Connection conn, boolean activeOnly) {
 		
@@ -171,8 +183,9 @@ public class MsInstrumentUtils {
 		String name = rs.getString("name");
 		String desc = rs.getString("description");
 		boolean active = rs.getBoolean("active");
+		boolean isMassSpec = rs.getBoolean("massSpec");
 		String color = rs.getString("color");
-		return new MsInstrument(id, name, desc, active, color);
+		return new MsInstrument(id, name, desc, active, isMassSpec, color);
 	}
 
 	//--------------------------------------------------------------------------------------------
@@ -378,7 +391,7 @@ public class MsInstrumentUtils {
 		PreparedStatement stmt = null;
 		ResultSet rs = null;
 
-		String sql = "INSERT INTO " + DBConnectionManager.getInstrumentsTableSQL() + " (name, description, active, color) VALUES(?,?,?,?)";
+		String sql = "INSERT INTO " + DBConnectionManager.getInstrumentsTableSQL() + " (name, description, active, massSpec, color) VALUES(?,?,?,?,?)";
 		try
 		{
 			conn = getConnection();
@@ -386,7 +399,8 @@ public class MsInstrumentUtils {
 			stmt.setString(1, instrument.getNameOnly());
 			stmt.setString(2, instrument.getDescription());
 			stmt.setInt(3, instrument.isActive() ? 1 : 0);
-			stmt.setString(4, instrument.getColor());
+			stmt.setInt(4, instrument.isMassSpec() ? 1 : 0);
+			stmt.setString(5, instrument.getColor());
 			stmt.executeUpdate();
 		}
 		catch (SQLException e)
@@ -409,7 +423,7 @@ public class MsInstrumentUtils {
 		PreparedStatement stmt = null;
 		ResultSet rs = null;
 
-		String sql = "UPDATE " + DBConnectionManager.getInstrumentsTableSQL() + " SET name=?, description=?, active=?, color=? WHERE id=?";
+		String sql = "UPDATE " + DBConnectionManager.getInstrumentsTableSQL() + " SET name=?, description=?, active=?, massSpec=?, color=? WHERE id=?";
 		try
 		{
 			conn = getConnection();
@@ -417,8 +431,9 @@ public class MsInstrumentUtils {
 			stmt.setString(1, instrument.getNameOnly());
 			stmt.setString(2, instrument.getDescription());
 			stmt.setInt(3, instrument.isActive() ? 1 : 0);
-			stmt.setString(4, instrument.getColor());
-			stmt.setInt(5, instrument.getID());
+			stmt.setInt(4, instrument.isMassSpec() ? 1 : 0);
+			stmt.setString(5, instrument.getColor());
+			stmt.setInt(6, instrument.getID());
 			stmt.executeUpdate();
 		}
 		catch (SQLException e)

--- a/src/org/uwpr/instrumentlog/UsageBlockBase.java
+++ b/src/org/uwpr/instrumentlog/UsageBlockBase.java
@@ -193,6 +193,11 @@ public class UsageBlockBase implements Block
 		return TimeUtils.getHours(getStartDate(), getEndDate());
 	}
 
+	public static int getHours(UsageBlockBase block, List<Integer> accessoryInstrumentIds)
+	{
+		return accessoryInstrumentIds.contains(block.getInstrumentID()) ? 0 : block.getHours();
+	}
+
     public String toString() {
         StringBuilder buf = new StringBuilder();
         buf.append("Block ");

--- a/src/org/uwpr/scheduler/UsageBlockBaseWithRate.java
+++ b/src/org/uwpr/scheduler/UsageBlockBaseWithRate.java
@@ -3,13 +3,12 @@
  */
 package org.uwpr.scheduler;
 
-import org.uwpr.costcenter.CostUtils;
+
 import org.uwpr.costcenter.InstrumentRate;
+import org.uwpr.instrumentlog.MsInstrument;
 import org.uwpr.instrumentlog.UsageBlockBase;
-import org.uwpr.instrumentlog.UsageBlockBaseFilter;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 /**
  * UsageBlockBaseWithRate.java
@@ -65,5 +64,16 @@ public class UsageBlockBaseWithRate extends UsageBlockBase {
 		{
 			return BigDecimal.ZERO;
 		}
+	}
+
+	@Override
+	public int getHours()
+	{
+		// If this instrument is an add-on (e.g. HPLC) then we do not want the hours
+		// the instrument was used to count towards the total quota available to the user.
+		// HPLC will always be used with a mass spec instrument. Only the total mass spec
+		// instrument hours should count towards the quota.
+		MsInstrument instrument = rate!= null ? rate.getInstrument() : null;
+		return instrument != null && instrument.isMassSpec() ? super.getHours() : 0;
 	}
 }

--- a/src/org/yeastrc/project/Project.java
+++ b/src/org/yeastrc/project/Project.java
@@ -1066,7 +1066,7 @@ public abstract class Project implements Comparable, IData, ComparableProject {
 		}
 		// Filter the instrument operator list to the users listed on the project
 		List<Researcher> projectResearchers = getResearchers();
-		List<Researcher> projectInstrumentOperators = new ArrayList<Researcher>(projectResearchers.size());
+		Set<Researcher> projectInstrumentOperators = new HashSet<Researcher>(projectResearchers.size());
 		for(Researcher researcher: projectResearchers)
 		{
 			if(instrumentOperatorIds.contains(researcher.getID()))
@@ -1079,7 +1079,7 @@ public abstract class Project implements Comparable, IData, ComparableProject {
 		{
 			projectInstrumentOperators.add(pi);
 		}
-		return projectInstrumentOperators;
+		return new ArrayList<>(projectInstrumentOperators);
 	}
 	/**
 	 * Returns the project submit date as a String

--- a/src/org/yeastrc/project/payment/PaymentMethodUsage.java
+++ b/src/org/yeastrc/project/payment/PaymentMethodUsage.java
@@ -7,6 +7,7 @@ import org.uwpr.costcenter.Cost;
 
 import java.math.BigDecimal;
 import java.sql.SQLException;
+import java.text.NumberFormat;
 
 /**
  * PaymentMethod.java
@@ -25,9 +26,10 @@ public class PaymentMethodUsage
 		invoicedCost = PaymentMethodDAO.getInstance().getInvoicedCost(paymentMethodId);
 	}
 
-    public BigDecimal getTotalCost() {
+    public BigDecimal getTotalCost()
+	{
 		return cost == null ? BigDecimal.ZERO : cost.getTotal();
-    }
+	}
 
 	public BigDecimal getInstrumentCost()
 	{
@@ -39,7 +41,33 @@ public class PaymentMethodUsage
 		return cost == null ? BigDecimal.ZERO : cost.setupCost;
 	}
 
-    public BigDecimal getInvoicedCost() {
-        return invoicedCost == null ? BigDecimal.ZERO : invoicedCost.getTotal();
-    }
+	public BigDecimal getInvoicedCost()
+	{
+		return invoicedCost == null ? BigDecimal.ZERO : invoicedCost.getTotal();
+	}
+
+	public String getTotalCostFormatted()
+	{
+		return format(getTotalCost());
+	}
+
+	public String getInstrumentCostFormatted()
+	{
+		return format(getInstrumentCost());
+	}
+
+	public String getSetupCostFormatted()
+	{
+		return format(getSetupCost());
+	}
+
+	public String getInvoicedCostFormatted()
+	{
+		return format(getInvoicedCost());
+	}
+
+	private String format(BigDecimal cost)
+	{
+		return NumberFormat.getCurrencyInstance().format(cost);
+	}
 }

--- a/src/org/yeastrc/www/admin/AddInstrumentForm.java
+++ b/src/org/yeastrc/www/admin/AddInstrumentForm.java
@@ -7,13 +7,11 @@
 package org.yeastrc.www.admin;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.sound.midi.Instrument;
 
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.action.ActionMessage;
-import org.uwpr.instrumentlog.InstrumentColors;
 
 import java.util.regex.Pattern;
 
@@ -26,6 +24,7 @@ public class AddInstrumentForm extends ActionForm {
     private String name;
     private String description;
     private boolean active;
+    private boolean massSpec;
     private String color;
 
     private static final Pattern HEX_PATTERN = Pattern.compile("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$");
@@ -82,6 +81,14 @@ public class AddInstrumentForm extends ActionForm {
     public void setActive(boolean active)
     {
         this.active = active;
+    }
+
+    public boolean isMassSpec() {
+        return massSpec;
+    }
+
+    public void setMassSpec(boolean massSpec) {
+        this.massSpec = massSpec;
     }
 
     public String getColor()

--- a/src/org/yeastrc/www/admin/AddInstrumentFormAction.java
+++ b/src/org/yeastrc/www/admin/AddInstrumentFormAction.java
@@ -50,7 +50,10 @@ public class AddInstrumentFormAction extends Action {
             return mapping.findForward("Failure");
         }
 
-        request.setAttribute("addInstrumentForm", new AddInstrumentForm());
+        AddInstrumentForm newForm = new AddInstrumentForm();
+        newForm.setActive(true);
+        newForm.setMassSpec(true);
+        request.setAttribute("addInstrumentForm", newForm);
         // Kick it to the view page
         return mapping.findForward("Success");
 

--- a/src/org/yeastrc/www/admin/EditInstrumentAction.java
+++ b/src/org/yeastrc/www/admin/EditInstrumentAction.java
@@ -79,6 +79,7 @@ public class EditInstrumentAction extends Action {
         myForm.setName(instrument.getNameOnly());
         myForm.setDescription(instrument.getDescription());
         myForm.setActive(instrument.isActive());
+        myForm.setMassSpec(instrument.isMassSpec());
         String color = instrument.getHexColor(); // Colors stored in the database do not start with #.
         myForm.setColor(color == null ? InstrumentColors.getColor(instrument.getID()) : color);
         request.setAttribute("addInstrumentForm", myForm);

--- a/src/org/yeastrc/www/admin/SaveInstrumentAction.java
+++ b/src/org/yeastrc/www/admin/SaveInstrumentAction.java
@@ -70,6 +70,7 @@ public class SaveInstrumentAction extends Action
         instrument.setDescription(myForm.getDescription());
         instrument.setColor(color);
         instrument.setActive(myForm.isActive());
+        instrument.setMassSpec(myForm.isMassSpec());
         instrUtils.saveInstrument(instrument);
 
         // Kick it to the view page


### PR DESCRIPTION
- Added a boolean "massSpec" column to the msInstrument table. Entries in this table will not always be mass spec instruments. They could be add-ons devices such as HPLC.  Users sign up for these devices separately from the mass spec instrument. We do not want the non-mass spec instrument time to count towards the maximum instrument time quota available to a user.
- Fixed formatting for some of the cost columns
- newPaymentMethod.jsp: this was missing from the previous commit related to worktags
- Bug fix: show unique instrument operators in the instrument sign-up form. If PI and researcher on a project were the same user then they were listed twice in the instrument operator field.